### PR TITLE
Add Agent Trust to Guardrails / Agent Security

### DIFF
--- a/data/sections.json
+++ b/data/sections.json
@@ -898,6 +898,29 @@
                   "url": "https://github.com/ArmorerLabs/Armorer-Guard"
                 }
               ]
+            },
+            {
+              "name": "Agent Trust",
+              "repo": "Rain-ouroboros/agent-trust",
+              "org": "Rain Ouroboros",
+              "desc": "Runtime-enforced agent security manifest with 24+ boundaries, LLM semantic classification, advisory receipts, and ed25519-signed runtime manifest for verifiable agent trust. Python package on PyPI.",
+              "status": [
+                "open_source"
+              ],
+              "related": [
+                {
+                  "label": "agent-audit",
+                  "url": "https://github.com/scadastrangelove/agent-audit"
+                },
+                {
+                  "label": "asamm",
+                  "url": "https://github.com/scadastrangelove/asamm"
+                },
+                {
+                  "label": "agentfence",
+                  "url": "https://github.com/agentfence/agentfence"
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
## Summary

Adds [Agent Trust](https://github.com/Rain-ouroboros/agent-trust) — a runtime-enforced agent security manifest with ed25519-signed boundary verification — to the Guardrails / Agent Security section.

Agent Trust is an open-source (MIT) Python library that generates a verifiable, runtime-enforced manifest of agent boundaries. Unlike self-reported security claims, the manifest is:
- Generated from live enforcement objects (tool allowlists, boundary catalogs, protected paths)
- Signed by the runtime (not the agent) via ed25519
- Verifiable by third parties using a published public key

This tool is directly relevant to the agent security category as it provides a structural (not behavioural) approach to agent boundary enforcement.