### PR TITLE
Add TAP (credential-isolation proxy for AI agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Securing the AI agents themselves — auditing coding agents (Claude Code, Codex
   - **Related:** [microsandbox](https://github.com/superradcompany/microsandbox) · [defenseclaw](https://github.com/cisco-ai-defense/defenseclaw)
 - **[DvalinCode](https://github.com/arthurpanhku/dvalincode)** 🟢 — Local-first AI coding agent with runtime governance controls: org/repo policy gates for tools, models, MCP servers, paths, and commands, plus provider/shell/MCP egress controls and hash-chained audit logs. — **note:** young project with limited independent adoption signal. *(★ 95 · updated 2026-07-22)*
   - **Related:** [h5i](https://github.com/h5i-dev/h5i) · [Pipelock](https://github.com/luckyPipewrench/pipelock) · [Armorer Guard](https://github.com/ArmorerLabs/Armorer-Guard)
+- **[TAP](https://github.com/holonym-foundation/tap-oss)** 🟢 — Credential-isolation proxy and MCP server for AI agents: agents send placeholder credentials, TAP injects real secrets server-side after per-action policy checks, with optional human approval on sensitive calls. *(human.tech)*
 
 ---
 

--- a/data/sections.json
+++ b/data/sections.json
@@ -1206,6 +1206,15 @@
                 "updated": "2026-07-22",
                 "snapshot": "2026-07-23"
               }
+            },
+            {
+              "name": "TAP",
+              "repo": "holonym-foundation/tap-oss",
+              "org": "human.tech",
+              "desc": "Credential-isolation proxy and MCP server for AI agents: agents send placeholder credentials, TAP injects real secrets server-side after per-action policy checks, with optional human approval on sensitive calls.",
+              "status": [
+                "open_source"
+              ]
             }
           ]
         }


### PR DESCRIPTION
Adds **TAP** ([holonym-foundation/tap-oss](https://github.com/holonym-foundation/tap-oss), Apache-2.0) to *AI Agent & Coding-Agent Security → Runtime Protection & Enforcement*, appended per existing entry order.

Edited `data/sections.json` per CONTRIBUTING; `gen_readme.py` run and `--check` passes. Public, installable (self-host via repo; hosted service + remote MCP endpoint at `mcp.tap.human.tech/mcp`). Description kept factual and one sentence.

Disclosure: submitted on behalf of the tap-oss maintainers (human.tech).

🤖 Generated with [Claude Code](https://claude.com/claude-code)