### PR TITLE
Add ShiftGrid to Pentest & Red-Team Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Autonomous and semi-autonomous AI agents for penetration testing, exploitation, 
 - **[cyber-security-llm-agents](https://github.com/NVISOsecurity/cyber-security-llm-agents)** 🟢⚠️ — AutoGen-based agents for cybersecurity tasks (shown at RSAC 2024). *(NVISO)* *(★ 381 · updated 2024-05-07)*
 - **[Pentest-Swarm-AI](https://github.com/Armur-Ai/Pentest-Swarm-AI)** 🟢 — Swarm-intelligence multi-agent pentest with stigmergic blackboard coordination (Go). *(★ 2,110 · updated 2026-06-20)*
 - **[hackGPT](https://github.com/NoDataFound/hackGPT)** 🟢⚠️ — LLM offensive-security toolkit. *(★ 1,195 · updated 2025-07-21)*
+- **[ShiftGrid](https://github.com/BuFuuu/shiftgrid)** 🟢 — Prompt engine that turns Claude Code into a transparent, human-in-the-loop pentester, structuring engagements through checklists, observations, and notes exposed via an agent-facing API.
 
 ---
 

--- a/data/sections.json
+++ b/data/sections.json
@@ -2042,6 +2042,17 @@
             "updated": "2025-07-21",
             "snapshot": "2026-07-26"
           }
+        },
+        {
+          "name": "ShiftGrid",
+          "repo": "BuFuuu/shiftgrid",
+          "desc": "Prompt engine that turns Claude Code into a transparent, human-in-the-loop pentester, structuring engagements through checklists, observations, and notes exposed via an agent-facing API.",
+          "status": [
+            "open_source"
+          ],
+          "flags": [
+            "authorized_testing_only"
+          ]
         }
       ]
     },


### PR DESCRIPTION
Adds **ShiftGrid** ([BuFuuu/shiftgrid](https://github.com/BuFuuu/shiftgrid)) — a prompt engine that turns Claude Code into a transparent, human-in-the-loop pentester — to the *Pentest & Red-Team Agents* section.

- Edited `data/sections.json` and regenerated `README.md` with `gen_readme.py` (`--check` passes).
- MIT-licensed, public repo → `status: open_source`; `authorized_testing_only` flag.
- Did not run the metrics refresh (avoids rewriting every entry's snapshot); happy to add a `metrics` block if you'd prefer.

**Disclosure:** I'm the author of ShiftGrid.
