### PR TITLE
Add BugTraceAI (Pentest & Red-Team Agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Autonomous and semi-autonomous AI agents for penetration testing, exploitation, 
 - **[cyber-security-llm-agents](https://github.com/NVISOsecurity/cyber-security-llm-agents)** 🟢⚠️ — AutoGen-based agents for cybersecurity tasks (shown at RSAC 2024). *(NVISO)* *(★ 381 · updated 2024-05-07)*
 - **[Pentest-Swarm-AI](https://github.com/Armur-Ai/Pentest-Swarm-AI)** 🟢 — Swarm-intelligence multi-agent pentest with stigmergic blackboard coordination (Go). *(★ 2,110 · updated 2026-06-20)*
 - **[hackGPT](https://github.com/NoDataFound/hackGPT)** 🟢⚠️ — LLM offensive-security toolkit. *(★ 1,195 · updated 2025-07-21)*
+- **[BugTraceAI](https://github.com/BugTraceAI/BugTraceAI)** 🟢⚠️ — Self-hosted autonomous multi-agent web-application scanner that chains recon, specialist exploit agents, Go fuzzers, and Playwright browser validation before emitting PoC-backed reports, shipped as a CLI engine, a real-time web dashboard, and a one-command Docker launcher. — **note:** AGPL-3.0 licensed; authorized testing only. Needs an LLM provider key (OpenRouter/Anthropic or compatible) or a local Ollama endpoint, and a heavy Docker runtime (Playwright browsers, Go fuzzers); components are versioned beta. *(★ 110 · updated 2026-07-27)*
+  - **Related:** [BugTraceAI-CLI](https://github.com/BugTraceAI/BugTraceAI-CLI) · [BugTraceAI-WEB](https://github.com/BugTraceAI/BugTraceAI-WEB) · [BugTraceAI-Launcher](https://github.com/BugTraceAI/BugTraceAI-Launcher)
 
 ---
 

--- a/data/sections.json
+++ b/data/sections.json
@@ -2071,6 +2071,40 @@
             "updated": "2025-07-21",
             "snapshot": "2026-07-26"
           }
+        },
+        {
+          "name": "BugTraceAI",
+          "repo": "BugTraceAI/BugTraceAI",
+          "desc": "Self-hosted autonomous multi-agent web-application scanner that chains recon, specialist exploit agents, Go fuzzers, and Playwright browser validation before emitting PoC-backed reports, shipped as a CLI engine, a real-time web dashboard, and a one-command Docker launcher.",
+          "note": "— **note:** AGPL-3.0 licensed; authorized testing only. Needs an LLM provider key (OpenRouter/Anthropic or compatible) or a local Ollama endpoint, and a heavy Docker runtime (Playwright browsers, Go fuzzers); components are versioned beta.",
+          "status": [
+            "open_source"
+          ],
+          "flags": [
+            "license_caveat",
+            "requires_api_key",
+            "heavy_runtime",
+            "authorized_testing_only"
+          ],
+          "related": [
+            {
+              "label": "BugTraceAI-CLI",
+              "url": "https://github.com/BugTraceAI/BugTraceAI-CLI"
+            },
+            {
+              "label": "BugTraceAI-WEB",
+              "url": "https://github.com/BugTraceAI/BugTraceAI-WEB"
+            },
+            {
+              "label": "BugTraceAI-Launcher",
+              "url": "https://github.com/BugTraceAI/BugTraceAI-Launcher"
+            }
+          ],
+          "metrics": {
+            "stars": 110,
+            "updated": "2026-07-27",
+            "snapshot": "2026-07-27"
+          }
         }
       ]
     },


### PR DESCRIPTION
Adds **BugTraceAI** to `Pentest & Red-Team Agents`.

[BugTraceAI](https://github.com/BugTraceAI/BugTraceAI) is a self-hosted, autonomous multi-agent web-application scanner: a recon stage feeds specialist exploit agents (XSS, SQLi, SSRF, XXE, CSTI, …), Go fuzzers and Playwright browser validation confirm candidates, and the pipeline emits PoC-backed reports. It ships as a CLI engine, a real-time web dashboard, and a one-command Docker launcher, which is why the umbrella repo is linked as canonical with the three components under `related`.

Disclosure: I am the author of the project.

**Entry criteria**

- Public, installable project — AGPL-3.0 across all repos, one-command Docker install via the Launcher.
- Canonical upstream repo linked (not a fork); components as `related` links.
- Adoption/maintenance signal: ~110★ on the umbrella repo, ~162★ on the CLI, commits within the last day.
- Caveats declared rather than glossed over: `license_caveat` (AGPL-3.0 copyleft), `requires_api_key` (LLM provider key, or a local Ollama endpoint), `heavy_runtime` (Docker + Playwright browsers + Go fuzzers), `authorized_testing_only`.
- Components are still versioned beta — called out in the note. Happy to move this to `WATCHLIST.md` instead if you'd prefer to wait for a stable tag.

**Changes**

- `data/sections.json` — one new entry, appended to `Pentest & Red-Team Agents`.
- `README.md` — regenerated with `python3 gen_readme.py`; `python3 gen_readme.py --check` passes. No hand-written badges; metrics are static snapshots dated 2026-07-27.