### PR TITLE
docs: add REA to reverse engineering tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **Type legend:** 🟢 public source / open-source · 🔬 research (paper / benchmark / dataset / framework) · 🟠 commercial with open components · ⚠️ restrictive, non-commercial, or unclear/no license — check before use.
 
-GitHub-hosted entries show static **★ stars** and **last-commit** snapshots; refresh them with `python3 scripts/update_github_metrics.py` before release. Latest snapshot: 2026-08-01. Hugging Face model entries show license, access, and artifact metadata. Ordering within a section favors flagship and actively maintained projects.
+GitHub-hosted entries show static **★ stars** and **last-commit** snapshots; refresh them with `python3 scripts/update_github_metrics.py` before release. Latest snapshot: 2026-08-04. Hugging Face model entries show license, access, and artifact metadata. Ordering within a section favors flagship and actively maintained projects.
 
 ---
 
@@ -430,6 +430,7 @@ LLM-assisted binary analysis and traffic inspection.
   - **Related:** [Burp-extension-for-GPT](https://github.com/tenable/Burp-extension-for-GPT)
 - **[Burp-extension-for-GPT](https://github.com/tenable/Burp-extension-for-GPT)** 🟢 — Burp extension to analyze HTTP traffic with GPT. *(Tenable)* *(★ 115 · updated 2023-05-01)*
   - **Related:** [burpgpt](https://github.com/aress31/burpgpt)
+- **[REA](https://github.com/morluto/rea)** 🟢 — Local CLI and MCP tools for agent-driven reverse engineering with Hopper and Ghidra, managed PE/CLI, JavaScript/Electron apps, and browser runtimes. *(★ 168 · updated 2026-08-03)*
 
 ---
 

--- a/data/sections.json
+++ b/data/sections.json
@@ -3764,6 +3764,20 @@
             "updated": "2023-05-01",
             "snapshot": "2026-08-01"
           }
+        },
+        {
+          "name": "REA",
+          "repo": "morluto/rea",
+          "desc": "Local CLI and MCP tools for agent-driven reverse engineering with Hopper and Ghidra, managed PE/CLI, JavaScript/Electron apps, and browser runtimes.",
+          "status": [
+            "open_source"
+          ],
+          "license": "MIT",
+          "metrics": {
+            "stars": 168,
+            "updated": "2026-08-03",
+            "snapshot": "2026-08-04"
+          }
         }
       ]
     },


### PR DESCRIPTION
## Summary

Adds [REA](https://github.com/morluto/rea) to the Reverse Engineering section through the canonical `data/sections.json` source, with the generated README update.

REA provides local CLI and MCP tools for agent-driven reverse engineering with Hopper and Ghidra, managed PE/CLI files, JavaScript/Electron applications, and browser runtimes. The entry records its MIT license and current repository metrics.

## Validation

- `python3 -m json.tool data/sections.json`
- `python3 gen_readme.py`
- `python3 gen_readme.py --check`
- `git diff --check`