### PR TITLE
Add little-canary to LLM Red-Teaming & Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ Tools for attacking and defending LLM applications themselves.
 - **[JailbreakLLMs](https://github.com/TrustAIRLab/JailbreakLLMs)** 🔬⚠️ — Research dataset of 6,387 ChatGPT prompts, including in-the-wild jailbreak prompts from Reddit, Discord, websites, and open datasets. *(★ 23 · updated 2024-02-21)*
 - **[Do-Not-Answer](https://github.com/Libr-AI/do-not-answer)** 🟢🔬 — Dataset for evaluating LLM safeguards on unsafe or policy-sensitive prompts. *(★ 339 · updated 2024-06-07)*
 - **[prompt-injection-defenses](https://github.com/tldrsec/prompt-injection-defenses)** 🟢⚠️ — Curated catalog of practical defenses against prompt injection. *(★ 719 · updated 2025-02-22)*
+- **[little-canary](https://github.com/hermes-labs-ai/little-canary)** 🟢 — Prompt-injection preflight sensor: routes untrusted input through a powerless sacrificial model first and reads the response residue for compromise, returning pass/flag/block before the primary agent acts. *(★ 26 · updated 2026-08-03)*
 
 ### Prompt-Injection Classifier Models
 

--- a/data/sections.json
+++ b/data/sections.json
@@ -4510,6 +4510,19 @@
                 "updated": "2025-02-22",
                 "snapshot": "2026-08-05"
               }
+            },
+            {
+              "name": "little-canary",
+              "repo": "hermes-labs-ai/little-canary",
+              "desc": "Prompt-injection preflight sensor: routes untrusted input through a powerless sacrificial model first and reads the response residue for compromise, returning pass/flag/block before the primary agent acts.",
+              "status": [
+                "open_source"
+              ],
+              "metrics": {
+                "stars": 26,
+                "updated": "2026-08-03",
+                "snapshot": "2026-08-05"
+              }
             }
           ]
         },


### PR DESCRIPTION
## What

Adds `hermes-labs-ai/little-canary` under **LLM Red-Teaming & Guardrails → Scanners, Evals & Guardrails**, alongside Rebuff and Vigil.

little-canary is an inbound prompt-injection preflight sensor. Untrusted input first hits a powerless sacrificial model with no application tools or authority; a behavioral check then reads that model's response for compromise residue and returns pass/flag/block before the primary agent acts. It's explicit that this is a risk sensor, not a guarantee.

Apache-2.0, published on PyPI (`little-canary==0.3.3`), 26 stars, pushed 2026-08-03. The README documents an evidence-gate discipline (e.g. it reports `REPLAY UNAVAILABLE` and exits nonzero rather than fabricating a replay fixture when one isn't honestly available), which matches this list's "factual, verifiable metadata" bar.

## Checklist

- [x] Edited `data/sections.json`, not `README.md` directly, and regenerated with `python3 gen_readme.py`
- [x] `python3 gen_readme.py --check` passes
- [x] Entry validates against `data/schema.json`
- [x] Placed in the correct group per Entry Criteria (real, installable, public project; clear license)
- [x] Confirmed the project isn't already listed
