### PR TITLE
Add AgentInterdict to LLM Red-Teaming & Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ Tools for attacking and defending LLM applications themselves.
   - **Related:** [PromptFuzz](https://github.com/PromptFuzz/PromptFuzz) · [promptfoo](https://github.com/promptfoo/promptfoo)
 - **[Prompt SIREN](https://github.com/facebookresearch/prompt-siren)** 🟢🔬 — Research workbench for developing and evaluating prompt-injection attacks and defenses with state-machine agent control, AgentDojo/SWE-bench integrations, configuration sweeps, and reproducible result aggregation. *(Meta AI)* — **note:** experiment harness; running target evaluations requires model-provider credentials and may need Docker or browser extras depending on the selected environment. *(★ 59 · updated 2026-07-24)*
   - **Related:** [AgentDojo](https://github.com/ethz-spylab/agentdojo) · [PyRIT](https://github.com/microsoft/PyRIT)
+- **[AgentInterdict](https://github.com/BryanFiFife/AgentInterdict)** 🟢 — Local-first runtime that enforces retrieval-is-not-permission, origin-bound authority, and action-time re-scoring at the boundary where retrieved context becomes agent action. Published 96.5% block rate over a 200-attempt injection suite with 7 documented misses. *(Bryan Fi Fife)* — **note:** early-stage; published benchmark includes the 7 misses with payloads. Integrates with Hermes, OpenClaw, MCP, and REST. *(★ 3 · updated 2026-08-11)*
 
 ### Prompt-Injection Classifier Models
 

--- a/data/sections.json
+++ b/data/sections.json
@@ -4855,6 +4855,25 @@
                 "updated": "2026-07-24",
                 "snapshot": "2026-08-09"
               }
+            },
+            {
+              "name": "AgentInterdict",
+              "repo": "BryanFiFife/AgentInterdict",
+              "org": "Bryan Fi Fife",
+              "status": [
+                "open_source"
+              ],
+              "license": "MIT",
+              "flags": [
+                "early_stage"
+              ],
+              "desc": "Local-first runtime that enforces retrieval-is-not-permission, origin-bound authority, and action-time re-scoring at the boundary where retrieved context becomes agent action. Published 96.5% block rate over a 200-attempt injection suite with 7 documented misses.",
+              "note": "— **note:** early-stage; published benchmark includes the 7 misses with payloads. Integrates with Hermes, OpenClaw, MCP, and REST.",
+              "metrics": {
+                "stars": 3,
+                "updated": "2026-08-11",
+                "snapshot": "2026-08-11"
+              }
             }
           ]
         },


### PR DESCRIPTION
Local-first agent-security runtime enforcing retrieval-is-not-permission and six invariants at the context-to-action boundary. Published 96.5% block rate with 7 documented misses.