### PR TITLE
Add xaidr to Runtime Protection & Enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ Securing the AI agents themselves — auditing coding agents (Claude Code, Codex
   - **Related:** [nono](https://github.com/nolabs-ai/nono) · [gate.cat](https://github.com/BGMLAI/gate.cat)
 - **[ADR](https://github.com/uber/ADR)** 🟢🔬 — Agentic AI Detection and Response system combining cross-client agent telemetry, ADR-Bench security scenarios, and a dual-agent detector for suspicious intent, tool use, and execution traces. *(Uber)* — **note:** deployed at Uber and published with an MLSys 2026 paper; the open release includes the Sensor, benchmark, and Detector, but not ADR Prevention or the offline ADR Explorer. Default detector configurations require model-provider credentials. *(★ 1,435 · updated 2026-08-10)*
   - **Related:** [Pipelock](https://github.com/luckyPipewrench/pipelock) · [AgentLock](https://github.com/webpro255/agentlock)
+- **[xaidr](https://github.com/delphisecurity/xaidr)** 🟢 — In-process runtime security sensor for AI agents that inspects input, tool calls, output, and agent-to-agent envelopes inside the agent process, with structured shell-command classification, YAML policy, privilege tiers, an opt-in circuit breaker, and OpenTelemetry export. *(Delphi Security)*
+  - **Related:** [agentguard](https://github.com/GoPlusSecurity/agentguard) · [defenseclaw](https://github.com/cisco-ai-defense/defenseclaw)
 
 ---
 

--- a/data/sections.json
+++ b/data/sections.json
@@ -1668,6 +1668,25 @@
                 "updated": "2026-08-10",
                 "snapshot": "2026-08-16"
               }
+            },
+            {
+              "name": "xaidr",
+              "repo": "delphisecurity/xaidr",
+              "org": "Delphi Security",
+              "desc": "In-process runtime security sensor for AI agents that inspects input, tool calls, output, and agent-to-agent envelopes inside the agent process, with structured shell-command classification, YAML policy, privilege tiers, an opt-in circuit breaker, and OpenTelemetry export.",
+              "status": [
+                "open_source"
+              ],
+              "related": [
+                {
+                  "label": "agentguard",
+                  "url": "https://github.com/GoPlusSecurity/agentguard"
+                },
+                {
+                  "label": "defenseclaw",
+                  "url": "https://github.com/cisco-ai-defense/defenseclaw"
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
Adding xaidr to Runtime Protection & Enforcement. Disclosure: I'm the author.

In-process runtime security sensor for AI agents. Apache 2.0, on PyPI, zero dependencies. Differs from the existing entries in that section by embedding in agents you build rather than monitoring coding-agent harnesses, and by treating agent-to-agent envelopes as a first-class scan path.

Noting your entry criteria: the repository is recently public, so if you'd rather track it in WATCHLIST.md for now that's completely fine by me.

Edited data/sections.json only; gen_readme.py --check passes. I did not run update_github_metrics.py, so no unrelated snapshots are touched.