### PR TITLE
Add MARGINAL to Runtime Protection & Enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ Securing the AI agents themselves — auditing coding agents (Claude Code, Codex
   - **Related:** [Pipelock](https://github.com/luckyPipewrench/pipelock) · [AgentLock](https://github.com/webpro255/agentlock)
 - **[xaidr](https://github.com/delphisecurity/xaidr)** 🟢 — In-process runtime security sensor for AI agents that inspects input, tool calls, output, and agent-to-agent envelopes inside the agent process, with structured shell-command classification, YAML policy, privilege tiers, an opt-in circuit breaker, and OpenTelemetry export. *(Delphi Security)* — **note:** early-stage in-process sensor, not an isolation boundary; monitor mode is the default and unexpected scan failures fail open while emitting degraded telemetry. Published detection and false-positive figures are project-reported on its committed corpus. *(★ 22 · updated 2026-08-17)*
   - **Related:** [agentguard](https://github.com/GoPlusSecurity/agentguard) · [defenseclaw](https://github.com/cisco-ai-defense/defenseclaw)
+- **[MARGINAL](https://github.com/SignalLayerLabs/Marginal)** 🟢 — Local-first runtime governor for AI coding agents that detects proven no-progress repetition, records decision evidence, starts in Shadow Mode, and earns narrow enforcement only after repository-local evidence thresholds are met. — **note:** young project; Codex supports tool enforcement, while Claude Code and OpenCode integrations are observe-only. Enforcement is evidence-gated and failures fail open.
+  - **Related:** [AgentLock](https://github.com/webpro255/agentlock) · [xaidr](https://github.com/delphisecurity/xaidr)
 
 ---
 

--- a/data/sections.json
+++ b/data/sections.json
@@ -1697,6 +1697,29 @@
                 "updated": "2026-08-17",
                 "snapshot": "2026-08-17"
               }
+            },
+            {
+              "name": "MARGINAL",
+              "repo": "SignalLayerLabs/Marginal",
+              "desc": "Local-first runtime governor for AI coding agents that detects proven no-progress repetition, records decision evidence, starts in Shadow Mode, and earns narrow enforcement only after repository-local evidence thresholds are met.",
+              "license": "Apache-2.0",
+              "status": [
+                "open_source"
+              ],
+              "flags": [
+                "early_stage"
+              ],
+              "note": "— **note:** young project; Codex supports tool enforcement, while Claude Code and OpenCode integrations are observe-only. Enforcement is evidence-gated and failures fail open.",
+              "related": [
+                {
+                  "label": "AgentLock",
+                  "url": "https://github.com/webpro255/agentlock"
+                },
+                {
+                  "label": "xaidr",
+                  "url": "https://github.com/delphisecurity/xaidr"
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
## Summary

Adds MARGINAL to **AI Agent & Coding-Agent Security → Runtime Protection & Enforcement**.

MARGINAL is a local-first runtime governor for coding agents. It observes first, records evidence for proven no-progress repetition, and only earns narrow enforcement after repository-local evidence.

- Apache-2.0
- Codex: tool enforcement
- Claude Code / OpenCode: observe-only
- evidence-gated enforcement
- fail-open under uncertainty or failure

Disclosure: I maintain MARGINAL.

## Validation

- `python3 gen_readme.py --check` — pass
- structured data validation — pass
- `git diff --check` — pass

I intentionally did not run `update_github_metrics.py` to avoid unrelated repository-wide snapshot churn.
