### PR TITLE
Add Agentmetry to Runtime Protection & Enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ Securing the AI agents themselves — auditing coding agents (Claude Code, Codex
   - **Related:** [Pipelock](https://github.com/luckyPipewrench/pipelock) · [AgentLock](https://github.com/webpro255/agentlock)
 - **[xaidr](https://github.com/delphisecurity/xaidr)** 🟢 — In-process runtime security sensor for AI agents that inspects input, tool calls, output, and agent-to-agent envelopes inside the agent process, with structured shell-command classification, YAML policy, privilege tiers, an opt-in circuit breaker, and OpenTelemetry export. *(Delphi Security)* — **note:** early-stage in-process sensor, not an isolation boundary; monitor mode is the default and unexpected scan failures fail open while emitting degraded telemetry. Published detection and false-positive figures are project-reported on its committed corpus. *(★ 22 · updated 2026-08-17)*
   - **Related:** [agentguard](https://github.com/GoPlusSecurity/agentguard) · [defenseclaw](https://github.com/cisco-ai-defense/defenseclaw)
+- **[Agentmetry](https://github.com/blitzcrieg1/agentmetry)** 🟢 — Local-first flight recorder for AI coding agents and MCP servers that writes a hash-chained JSONL trail with RFC 6962 Merkle roots, applies MITRE-mapped sequence detection across a session, attests every 300s which agent surfaces are covered, uncovered, absent or unknown, and forwards to Splunk HEC, Elastic ECS, Google SecOps UDM or CloudEvents. — **note:** young project with limited independent adoption signal; it records and detects rather than blocks, and its README states that hooks are cooperative and that tamper-evident is not the same as attributable.
+  - **Related:** [HOL Guard](https://github.com/hashgraph-online/hol-guard) · [ADR](https://github.com/uber/ADR)
 
 ---
 

--- a/data/sections.json
+++ b/data/sections.json
@@ -1697,6 +1697,29 @@
                 "updated": "2026-08-17",
                 "snapshot": "2026-08-17"
               }
+            },
+            {
+              "name": "Agentmetry",
+              "repo": "blitzcrieg1/agentmetry",
+              "desc": "Local-first flight recorder for AI coding agents and MCP servers that writes a hash-chained JSONL trail with RFC 6962 Merkle roots, applies MITRE-mapped sequence detection across a session, attests every 300s which agent surfaces are covered, uncovered, absent or unknown, and forwards to Splunk HEC, Elastic ECS, Google SecOps UDM or CloudEvents.",
+              "license": "Apache-2.0",
+              "status": [
+                "open_source"
+              ],
+              "flags": [
+                "early_stage"
+              ],
+              "note": "— **note:** young project with limited independent adoption signal; it records and detects rather than blocks, and its README states that hooks are cooperative and that tamper-evident is not the same as attributable.",
+              "related": [
+                {
+                  "label": "HOL Guard",
+                  "url": "https://github.com/hashgraph-online/hol-guard"
+                },
+                {
+                  "label": "ADR",
+                  "url": "https://github.com/uber/ADR"
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
Adding [Agentmetry](https://github.com/blitzcrieg1/agentmetry) (Apache-2.0) to *AI Agent & Coding-Agent Security → Runtime Protection & Enforcement*, alongside ADR and xaidr.

Followed CONTRIBUTING: edited `data/sections.json`, regenerated with `python gen_readme.py`, and `gen_readme.py --check` reports up to date. Diff is 23 lines of data plus the 2 generated README lines, no reformatting.

**What it does that the group does not already cover.** It records and detects rather than blocks, which puts it closer to ADR than to the sandboxes and gateways around it. Two specifics:

- **Coverage attestation.** A heartbeat every 300s reports which agent surfaces are covered, uncovered, absent or unknown. Hooks are cooperative and removal cannot be prevented in user space, so the design goal is making removal visible instead of silent. `uncovered` and `absent` are deliberately separate states.
- **MCP drift, not one-time scanning.** It fingerprints what a server actually returns from `tools/list` over time. The signal is the conjunction of schema digest moved while config digest did not, which is the shape a rug pull takes after a server has shipped clean versions.

Also hash-chained JSONL with RFC 6962 Merkle roots and inclusion proofs, MITRE-mapped sequence rules with a benchmark corpus that replays locally (`agentmetry benchmark`), and forwarders for Splunk HEC, Elastic ECS, Google SecOps UDM and CloudEvents.

**On entry criteria.** It is young (July 2026) with modest independent adoption, so I marked it `early_stage` and wrote a note saying so, including that it records rather than blocks and that its own README distinguishes tamper-evident from attributable. If WATCHLIST.md is the better home until adoption signals are clearer, I am happy to move it there instead, and would rather do that than argue for the main list.

Disclosure: I maintain it.