### PR TITLE
Add Nemesis Forge (LLM-Driven Fuzzing / Harness & target generation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ Two families: (a) LLMs generating harnesses/targets for traditional fuzzing, and
 - **[Fuzz4All](https://github.com/fuzz4all/fuzz4all)** 🟢🔬 — "Universal" LLM-based fuzzer across compilers/languages (ICSE 2024). *(★ 336 · updated 2025-08-11)*
 - **[ChatAFL](https://github.com/ChatAFLndss/ChatAFL)** 🟢🔬 — LLM-guided protocol fuzzing extending AFLNet (NDSS'24). *(★ 392 · updated 2025-06-20)*
 - **[TitanFuzz](https://github.com/ise-uiuc/TitanFuzz)** 🟢🔬⚠️ — First LLM-based fuzzer for PyTorch/TensorFlow (ISSTA'23). *(★ 94 · updated 2023-09-10)*
+- **[Nemesis Forge](https://github.com/eobi/nemesisforge)** 🟢 — Autonomous discovery engine for memory-safety bugs in C/C++: an LLM proposes harnesses and triage routing, and eight deterministic oracles (sanitizer, differential, native-replay, controllability, exploitability, symbolic) decide what is certified. Findings are reported at the rung of an exploitability ladder that the evidence reaches, and every finding states what was **not** established. *(Obi Ebuka David)* — **note:** the model never certifies, so the whole verification path runs with no API key; harness synthesis is the only step that needs one. New project, so few external users yet. *(★ 0 · updated 2026-08-24)*
 
 ### Fuzzing the LLM
 


### PR DESCRIPTION
Adds [Nemesis Forge](https://github.com/eobi/nemesisforge) alongside oss-fuzz-gen, PromptFuzz and Fuzz4All.

**What it is.** An autonomous discovery engine for memory-safety bugs in C/C++. An LLM proposes harnesses and triage routing; eight deterministic oracles decide what is certified.

**Why it may fit this list specifically.** The list already covers both LLM-driven fuzzing and autotriage, and this project sits across the two. Its distinguishing property is structural rather than a feature: *a model may propose a candidate at any rung, and may certify none of them.* Certification comes only from oracles that are deterministic, independent of the proposer, and reproducible by a third party. In practice the entire verification path runs with no API key, which is easy to check:

```
python -m forge lab examples/harness_trunc.c --fuzz-time 30
```

Every finding also prints what was **not** established, for example `NOT shown: anything above rung 1: no oracle certified it`.

**Disclosure, since this list flags caveats.** I am the author. The project is new and has no external users yet; I marked it ★ 0 rather than omit the count. MIT, standard library only for the core, no server. The repository also ships a finding that was **retracted** after native replay, with the reason, because an engine that only ever confirms is not one worth trusting.

Format follows the surrounding entries: 🟢, author attribution, a `note:` for caveats, star/updated stamp.