### PR TITLE
Add whatileaked to AI Agent & Coding-Agent Security / Scanners & Auditors

### DIFF
--- a/data/sections.json
+++ b/data/sections.json
@@ -777,8 +777,14 @@
                 "updated": "2026-08-25",
                 "snapshot": "2026-08-30"
               }
+            },
+            {
+              "name": "whatileaked",
+              "repo": "selan-ai/whatileaked",
+              "org": "Selan",
+              "desc": "Scans local Claude Code, Codex and Cursor transcripts **and** instruction/memory files (CLAUDE.md, AGENTS.md) for credentials already sent to a model provider, using the gitleaks rule set unmodified; reports a rule name and one-way fingerprint instead of the secret, and `wipe` redacts findings in place. No network calls, no telemetry, zero dependencies; MIT."
             }
-          ]
+]
         },
         {
           "title": "Frameworks, Rule Standards & Benchmarks",


### PR DESCRIPTION
Adds whatileaked to Scanners & Auditors. Edited data/sections.json per CONTRIBUTING, not the generated README.

It scans what a coding agent has already written to disk. Transcripts (Claude Code, Codex, Cursor) hold credentials that were already sent to a model provider. Instruction and memory files (CLAUDE.md, AGENTS.md) are the sharper case, because the agent re-reads them at the start of every session, so a credential there keeps leaking until someone edits the file. `wipe` redacts findings in place.

Detection uses the gitleaks rule set unmodified. It never prints a credential, only a rule name and a one-way fingerprint. No network request, zero dependencies, MIT.

This replaces #73, which went stale against the current sections.json. Closing that one.

Disclosure: I wrote it. We also sell a proxy that redacts credentials before they leave the machine, so the scanner is standalone and dependency-free on purpose, to make it auditable.