### PR TITLE
Add sofagent to Runtime Protection & Enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **Type legend:** 🟢 public source / open-source · 🔬 research (paper / benchmark / dataset / framework) · 🟠 commercial with open components · ⚠️ restrictive, non-commercial, or unclear/no license — check before use.
 
-GitHub-hosted entries show static **★ stars** and **last-commit** snapshots; refresh them with `python3 scripts/update_github_metrics.py` before release. Latest snapshot: 2026-08-30. Hugging Face model entries show license, access, and artifact metadata. Ordering within a section favors flagship and actively maintained projects.
+GitHub-hosted entries show static **★ stars** and **last-commit** snapshots; refresh them with `python3 scripts/update_github_metrics.py` before release. Latest snapshot: 2026-08-31. Hugging Face model entries show license, access, and artifact metadata. Ordering within a section favors flagship and actively maintained projects.
 
 ---
 
@@ -226,6 +226,8 @@ Securing the AI agents themselves — auditing coding agents (Claude Code, Codex
   - **Related:** [Sandbox Probe](https://github.com/controlplaneio/sandbox-probe) · [AIO Sandbox](https://github.com/agent-infra/sandbox)
 - **[Lunar](https://github.com/TheLunarCompany/lunar)** 🟢🟠 — API and MCP gateway combining outbound-traffic visibility, policy enforcement, rate limits, retries, circuit breakers, and centralized MCP server aggregation for agent workloads. *(Lunar.dev)* — **note:** the repository is active but its latest formal GitHub release is from 2024; the README positions the open core for non-production or personal use and directs production deployments to commercial platform tiers. *(★ 485 · updated 2026-08-28)*
   - **Related:** [agentgateway](https://github.com/agentgateway/agentgateway) · [Bifrost](https://github.com/maximhq/bifrost)
+- **[sofagent](https://github.com/KongFangXun/sofagent)** 🟢 — Commit-time audit engine for AI coding agents that scans git diffs against 24 audit rules (secret leaks, out-of-scope edits, blind modifications without prior reads, commit-message prompt injection, unauthorized file changes) and writes an HMAC-signed, tamper-evident local audit history, with MCP tools for governance aggregation. *(★ 41 · updated 2026-08-28)*
+  - **Related:** [Pipelock](https://github.com/luckyPipewrench/pipelock)
 
 ---
 

--- a/data/sections.json
+++ b/data/sections.json
@@ -2156,6 +2156,26 @@
                 "updated": "2026-08-28",
                 "snapshot": "2026-08-30"
               }
+            },
+            {
+              "name": "sofagent",
+              "repo": "KongFangXun/sofagent",
+              "desc": "Commit-time audit engine for AI coding agents that scans git diffs against 24 audit rules (secret leaks, out-of-scope edits, blind modifications without prior reads, commit-message prompt injection, unauthorized file changes) and writes an HMAC-signed, tamper-evident local audit history, with MCP tools for governance aggregation.",
+              "license": "MIT",
+              "status": [
+                "open_source"
+              ],
+              "related": [
+                {
+                  "label": "Pipelock",
+                  "url": "https://github.com/luckyPipewrench/pipelock"
+                }
+              ],
+              "metrics": {
+                "stars": 41,
+                "updated": "2026-08-28",
+                "snapshot": "2026-08-31"
+              }
             }
           ]
         }


### PR DESCRIPTION
Adds [sofagent](https://github.com/KongFangXun/sofagent) to **Runtime Protection & Enforcement** (AI Agent & Coding-Agent Security).

**sofagent** is a commit-time audit engine for AI coding agents: it scans git diffs with 24 audit rules (secret leaks, out-of-scope edits, blind modifications without prior reads, prompt injection in commit messages, unauthorized file changes) and writes an HMAC-signed, tamper-evident local audit history. Ships MCP tools for governance aggregation and a doctor command for integrity checks.

- **Repo:** KongFangXun/sofagent
- **License:** MIT (detected upstream)
- **Status:** open_source
- **Section:** AI Agent & Coding-Agent Security → Runtime Protection & Enforcement (fits alongside nono / Pipelock / ToolHive — sofagent audits and governs what coding agents actually changed at commit time)
- Changes `data/sections.json` (per CONTRIBUTING) + regenerated `README.md` via `gen_readme.py` with the new entry; metrics filled from a live snapshot (stars 41, updated 2026-08-28) — happy to re-run `update_github_metrics.py` if maintainers prefer a fresh sweep.

I am the author and maintainer of sofagent.