### PR TITLE
data: add Norviq under Runtime Protection & Enforcement

### DIFF
--- a/data/sections.json
+++ b/data/sections.json
@@ -2156,6 +2156,34 @@
                 "updated": "2026-08-28",
                 "snapshot": "2026-08-30"
               }
+            },
+            {
+              "name": "Norviq",
+              "repo": "norviq-dev/norviq",
+              "desc": "Kubernetes policy enforcement point for LLM agent tool calls that content-hash pins each tool definition at discovery and evaluates every tools/call against OPA/Rego policy before the upstream MCP server receives it.",
+              "license": "Apache-2.0",
+              "status": [
+                "open_source"
+              ],
+              "flags": [
+                "early_stage"
+              ],
+              "note": "— **note:** ships in audit mode — the installed baseline records what it would have refused and lets the call proceed, and all shipped policy presets default to allow, so enforcement starts with the first rule an operator writes. The discovery-time description scanner is a documented heuristic and the project publishes the payloads that defeat it. Young project with limited independent adoption signal.",
+              "related": [
+                {
+                  "label": "Prismor",
+                  "url": "https://github.com/PrismorSec/prismor"
+                },
+                {
+                  "label": "mcp-context-protector",
+                  "url": "https://github.com/trailofbits/mcp-context-protector"
+                }
+              ],
+              "metrics": {
+                "stars": 18,
+                "updated": "2026-08-24",
+                "snapshot": "2026-09-01"
+              }
             }
           ]
         }


### PR DESCRIPTION
Adds **Norviq** under *AI Agent & Coding-Agent Security → Runtime Protection & Enforcement*.

**[norviq-dev/norviq](https://github.com/norviq-dev/norviq)** — Apache-2.0, Kubernetes policy enforcement point for LLM agent tool calls. It content-hash pins each tool definition at discovery and evaluates every `tools/call` against OPA/Rego policy before the upstream MCP server receives the call.

Nearest neighbours already in the section are Prismor, mcp-context-protector and Agentgateway; it differs from those in being a Kubernetes-native control plane with a policy engine rather than a local proxy or a sandbox.

### On the note field

I have written the caveat harder than a submitter normally would, because the two things a reader of a *security* list would most reasonably assume are both false here:

- **It ships in audit mode.** The installed baseline records what it would have refused and lets the call proceed. All shipped policy presets are `default decision = "allow"`, and a namespace with no policy of its own resolves to allow. Enforcement begins with the first rule an operator writes, not on install.
- **The discovery-time description scanner is a heuristic, and evadable.** That is the module's own docstring, not a caveat added for this submission. The project publishes the payload set that defeats it — base64, ROT13, a path spelled out in words, plain Spanish or German — with per-payload results.

`early_stage` is flagged and the note carries the standard limited-adoption-signal line. If you would rather this sit in `WATCHLIST.md` until there is independent adoption signal, that is a fair call and I will not argue it — 18 stars is thin, and most of those are people I know rather than users.

### Mechanics

- Edited `data/sections.json` only, per CONTRIBUTING ("Please edit `data/sections.json`, not the generated `README.md`").
- **I did not regenerate `README.md`.** `gen_readme.py` needs Python 3.10+ for its `str | None` annotations and I could not run it in this environment; the entry is hand-validated against `data/schema.json` instead — key set matches sibling entries exactly, `status` and `flags` are drawn from the schema enums, `desc` is a single sentence. Please regenerate before merging, or tell me and I will push the regenerated README.
- `metrics` is a manual snapshot (`stars: 18`, `updated: 2026-08-24`, `snapshot: 2026-09-01`) rather than output from `update_github_metrics.py`, which I did not run.

Disclosure: I maintain Norviq.
