### PR TITLE
Partner check: validate one synthetic Eggcracker receipt

### DIFF
--- a/.github/fixtures/lumi-hosted-proof-receipt-v1.json
+++ b/.github/fixtures/lumi-hosted-proof-receipt-v1.json
@@ -12,7 +12,7 @@
   "root_populated": 0,
   "source_commit": "1111111111111111111111111111111111111111",
   "source_tree_sha256": "2222222222222222222222222222222222222222222222222222222222222222",
-  "target_processes": 1,
+  "target_processes": 2,
   "target_survivors": 0,
   "trigger_to_empty_ms": 2.5,
   "workload_detection_performed": false

--- a/.github/fixtures/lumi-hosted-proof-receipt-v1.json
+++ b/.github/fixtures/lumi-hosted-proof-receipt-v1.json
@@ -1,0 +1,19 @@
+{
+  "canary_survived": true,
+  "changes_made": true,
+  "cleanup_complete": true,
+  "descendant_cgroups_checked": 2,
+  "installation_performed": false,
+  "journal_history_may_persist": true,
+  "mode": "containment-primitive-probe",
+  "network_requests_made": false,
+  "primitive": "pidfd-stop+cgroup.kill",
+  "result": "TERMINATED",
+  "root_populated": 0,
+  "source_commit": "1111111111111111111111111111111111111111",
+  "source_tree_sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+  "target_processes": 1,
+  "target_survivors": 0,
+  "trigger_to_empty_ms": 2.5,
+  "workload_detection_performed": false
+}

--- a/.github/workflows/validate-lumi-hosted-proof-receipt.yml
+++ b/.github/workflows/validate-lumi-hosted-proof-receipt.yml
@@ -1,0 +1,17 @@
+name: Validate Lumi Eggcracker receipt
+
+on:
+  pull_request:
+    paths:
+      - ".github/fixtures/lumi-hosted-proof-receipt-v1.json"
+      - ".github/workflows/validate-lumi-hosted-proof-receipt.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-lumi-receipt:
+    uses: noqt/Lumi-Eggcracker/.github/workflows/validate-hosted-proof-receipt.yml@bf6910dbd83d30a50a486f84ac0fa96a0244e23e
+    with:
+      receipt: .github/fixtures/lumi-hosted-proof-receipt-v1.json


### PR DESCRIPTION
This turns the current partner check from #69 into a real public repository run.

It adds:

- one independently authored synthetic v1 receipt;
- one path-scoped workflow calling Eggcracker’s reusable validator at immutable commit `bf6910dbd83d30a50a486f84ac0fa96a0244e23e`.

The job has read-only contents permission, passes no secrets, exposes no outputs, and uploads nothing. A green run proves only that this repository can call the current workflow and that the synthetic receipt satisfies the current structure contract.

If repository policy blocks the external reusable workflow, fixture, pin, or Actions approval, the exact blocker is enough. If the validator itself fails, we’ll own the fix.

This is deliberately temporary; it can be closed after one run if you don’t want to keep the check.