### PR TITLE
Add Open-ReverseLab to Reverse Engineering section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **Type legend:** 🟢 public source / open-source · 🔬 research (paper / benchmark / dataset / framework) · 🟠 commercial with open components · ⚠️ restrictive, non-commercial, or unclear/no license — check before use.
 
-GitHub-hosted entries show static **★ stars** and **last-commit** snapshots; refresh them with `python3 scripts/update_github_metrics.py` before release. Latest snapshot: 2026-09-07. Hugging Face model entries show license, access, and artifact metadata. Ordering within a section favors flagship and actively maintained projects.
+GitHub-hosted entries show static **★ stars** and **last-commit** snapshots; refresh them with `python3 scripts/update_github_metrics.py` before release. Latest snapshot: 2026-09-08. Hugging Face model entries show license, access, and artifact metadata. Ordering within a section favors flagship and actively maintained projects.
 
 ---
 
@@ -522,6 +522,8 @@ LLM-assisted binary analysis and traffic inspection.
 - **[Burp-extension-for-GPT](https://github.com/tenable/Burp-extension-for-GPT)** 🟢 — Burp extension to analyze HTTP traffic with GPT. *(Tenable)* *(★ 116 · updated 2023-05-01)*
   - **Related:** [burpgpt](https://github.com/aress31/burpgpt)
 - **[REA](https://github.com/morluto/rea)** 🟢 — Local CLI and MCP toolkit for agent-assisted reverse engineering of native binaries, managed PE/CLI files, JavaScript/Electron apps, and browser runtimes, using Hopper or an operator-provided Ghidra installation. — **note:** deep native analysis uses separately licensed Hopper or operator-installed Ghidra. Setup can modify agent MCP registrations after interactive approval, and dynamic providers run with the current user's permissions; analyze only authorized artifacts. *(★ 346 · updated 2026-08-14)*
+  - **Related:** [GhidraMCP](https://github.com/LaurieWired/GhidraMCP) · [ReVa](https://github.com/cyberkaida/reverse-engineering-assistant)
+- **[Open-ReverseLab](https://github.com/LING71671/open-reverselab)** 🟢⚠️ — Agent-native AI reverse-engineering platform whose MCP server exposes Ghidra headless analysis (ghidra_headless_analyze, ghidra_summary_*) plus Frida, x64dbg, Rizin and YARA tooling, backed by a runnable CTF/APK/PE attack knowledge base. *(★ 1,101 · updated 2026-09-08)*
   - **Related:** [GhidraMCP](https://github.com/LaurieWired/GhidraMCP) · [ReVa](https://github.com/cyberkaida/reverse-engineering-assistant)
 
 ---

--- a/data/sections.json
+++ b/data/sections.json
@@ -5004,6 +5004,33 @@
             "updated": "2026-08-14",
             "snapshot": "2026-08-17"
           }
+        },
+        {
+          "name": "Open-ReverseLab",
+          "repo": "LING71671/open-reverselab",
+          "desc": "Agent-native AI reverse-engineering platform whose MCP server exposes Ghidra headless analysis (ghidra_headless_analyze, ghidra_summary_*) plus Frida, x64dbg, Rizin and YARA tooling, backed by a runnable CTF/APK/PE attack knowledge base.",
+          "status": [
+            "open_source"
+          ],
+          "license": "GPL-3.0",
+          "flags": [
+            "copyleft"
+          ],
+          "related": [
+            {
+              "label": "GhidraMCP",
+              "url": "https://github.com/LaurieWired/GhidraMCP"
+            },
+            {
+              "label": "ReVa",
+              "url": "https://github.com/cyberkaida/reverse-engineering-assistant"
+            }
+          ],
+          "metrics": {
+            "stars": 1101,
+            "updated": "2026-09-08",
+            "snapshot": "2026-09-08"
+          }
         }
       ]
     },


### PR DESCRIPTION
## What

Adds [Open-ReverseLab](https://github.com/LING71671/open-reverselab) to the **Reverse Engineering** section of `data/sections.json` and regenerated `README.md` with `python3 gen_readme.py`.

## Entry

- **repo:** `LING71671/open-reverselab`
- **status:** `open_source` (GPL-3.0)
- **flags:** `copyleft` (rendered 🟢⚠️ per the type legend)
- **desc:** Agent-native AI reverse-engineering platform whose MCP server exposes Ghidra headless analysis (ghidra_headless_analyze, ghidra_summary_*) plus Frida, x64dbg, Rizin and YARA tooling, backed by a runnable CTF/APK/PE attack knowledge base.
- **related:** GhidraMCP · ReVa

## Checks

- [x] `python3 gen_readme.py` regenerated README (only this entry + snapshot date changed)
- [x] `python3 gen_readme.py --check` passes
- [x] metrics filled as static snapshot (★ 1,101 · updated 2026-09-08)

## Why

The list already covers single-tool RE bridges (GhidraMCP, ReVa, x64dbg_mcp…). Open-ReverseLab is the workspace/lab variant: one MCP server exposing Ghidra headless + Frida + x64dbg + Rizin + YARA, plus a runnable CTF/APK/PE attack knowledge base so agents get both tooling and methodology.